### PR TITLE
Migrate Neovim installation to bash with plugin restoration

### DIFF
--- a/.claude/tasks/2025-07-07-bash-migration.md
+++ b/.claude/tasks/2025-07-07-bash-migration.md
@@ -1,15 +1,49 @@
 # Bash Migration Epic
 
-## Current Status (July 11, 2025)
+## Current Status (July 12, 2025)
 
 **Task**: Migrate dotfiles installation infrastructure from custom zsh to industry-standard bash + shellcheck + bats
-**Approach**: Enhanced 3-phase migration with setup.bash at the center for maximum tooling leverage
-**Current**: Phase 1 nearing completion - core utilities and 4 installation scripts migrated, setup.bash pending
+**Approach**: Parallel development - building complete bash setup system alongside existing zsh system
+**Current**: Phase 1 nearly complete - setup.bash + 7 installation scripts + all core utilities migrated
+
+### Parallel System Status
+
+**Bash setup system** (`setup.bash`):
+- ✅ Core utilities: machine-detection, prerequisite-validation, dry-run, error-handling
+- ✅ Installation scripts: ssh, github, homebrew, rust, node, neovim, symlinks  
+- ✅ Test coverage: 50+ comprehensive tests across all components
+- ✅ Quality: Zero shellcheck warnings across all bash files
+- ✅ Integration: setup.bash orchestrates all available bash scripts
+
+**Zsh setup system** (`setup.zsh`):
+- ✅ Fully functional and unchanged
+- ✅ Still the primary/production setup method
+- ✅ Uses some shared bash utilities (machine-detection, etc.)
+- ✅ Independent operation - no dependency on bash migration progress
 
 ## Migration Strategy
 
+**CRITICAL: Parallel Development Approach**
+
+This migration uses a **parallel development strategy** - we are building a complete bash-based setup flow alongside the existing zsh setup, NOT replacing it incrementally:
+
+- **Existing system**: `setup.zsh` + `bin/install/*.zsh` (continues to work, unchanged)
+- **New parallel system**: `setup.bash` + `bin/install/*.bash` (being built independently)
+- **Shared utilities**: `bin/lib/*.bash` (used by both systems during transition)
+
+**Why parallel?**
+- Zero disruption to existing workflows during development
+- Complete system validation before any replacement
+- Easy rollback if issues discovered
+- Allows thorough testing of new approach
+
+**Integration points**:
+- `setup.bash` sources bash installation scripts as they become available
+- Missing bash scripts fall back to zsh versions during transition
+- Both systems can coexist indefinitely until cutover decision
+
 ### Phase 1: Setup + Core Infrastructure Migration (IN PROGRESS - Enhanced Scope)
-**Goal**: Migrate setup.bash + core installation scripts + shared utilities for maximum tooling leverage
+**Goal**: Build complete bash setup system + core installation scripts + shared utilities for maximum tooling leverage
 
 #### Completed PRs
 
@@ -63,6 +97,34 @@
   - `bin/install/symlinks.bash` - Bash replacement for symlinks installation
   - `test/setup/test-symlink-utils-bash.bats` - Comprehensive symlink tests
 - **Status**: MERGED - Symlink functionality fully migrated to bash
+
+##### ✅ PR #22: Setup.bash Entry Point (MERGED)
+- **Files Created**:
+  - `setup.bash` - Main entry point for bash setup system
+- **Status**: MERGED - Parallel bash setup system established
+
+##### ✅ PR #23: Rust Installation Migration (MERGED)
+- **Files Created**:
+  - `bin/install/rust.bash` - Bash replacement for rust.zsh
+  - `lib/rust-utils.bash` - Rust installation utilities  
+  - Comprehensive test suite with 7 tests
+- **Status**: MERGED - Rust installation fully migrated to bash
+
+##### ✅ PR #24: Node.js Installation Migration (MERGED)
+- **Files Created**:
+  - `bin/install/node.bash` - Bash replacement for node.zsh
+  - `lib/node-utils.bash` - Node/fnm installation utilities
+  - Comprehensive test suite with 7 tests
+- **Status**: MERGED - Node.js installation fully migrated to bash
+
+##### 🔄 PR #25: Neovim Installation Migration (IN REVIEW)
+- **Files Created**:
+  - `bin/install/neovim.bash` - Bash replacement for neovim.zsh
+  - `lib/neovim-utils.bash` - Neovim configuration utilities
+  - Comprehensive test suite with 7 tests
+- **Files Updated**:
+  - `setup.bash` - Added integration for rust.bash, node.bash, neovim.bash
+- **Status**: Ready for merge - Neovim installation migrated + setup.bash integration complete
 
 ### Phase 2: Remaining Script Migration (Pending)
 **Goal**: Migrate remaining installation scripts using established three-tier architecture
@@ -173,10 +235,23 @@ test/install/test-{component}-installation.bats  # Integration tests
 - **Maximum leverage**: Shellcheck + bats testing for all shared business logic
 - **Example**: `lib/homebrew-utils.bash` used by both `setup.bash` and `bin/update/homebrew.zsh`
 
-### Enhanced Migration Boundary
-- **→ Bash infrastructure**: setup.bash, bin/install/*.bash, bin/lib/*.bash, shared utilities
-- **← Zsh user experience**: config/zsh/*, bin/update/*.zsh, interactive aliases/functions
-- **Benefit**: Maximum tooling leverage while preserving rich user shell experience
+### Parallel System Boundaries
+
+**Bash setup system** (new, being built):
+- `setup.bash` - Main entry point with comprehensive error handling and validation
+- `bin/install/*.bash` - Installation scripts with shellcheck compliance and bats testing
+- `bin/lib/*.bash` - Shared utilities used by both setup systems
+- **Benefits**: Professional tooling (shellcheck + bats), better error handling, consistent behavior
+
+**Zsh setup system** (existing, unchanged):
+- `setup.zsh` - Original entry point, continues to work
+- `bin/install/*.zsh` - Original installation scripts, still functional
+- `config/zsh/*`, `bin/update/*.zsh` - Interactive user experience (unchanged)
+- **Benefits**: Rich shell features, established workflows, user familiarity
+
+**Shared components** (used by both):
+- `bin/lib/*.bash` - Core utilities (machine detection, prerequisites, etc.)
+- Configuration files and symlink targets (unchanged)
 
 ## Discovered Issues
 

--- a/bin/install/neovim.bash
+++ b/bin/install/neovim.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Neovim installation script (bash version)
+# Clones Neovim configuration and restores plugins
+
+# shellcheck disable=SC1091  # Don't follow sourced files
+
+set -euo pipefail
+
+# Load Neovim utilities
+source "${DOTFILES:-$HOME/Repos/ooloth/dotfiles}/lib/neovim-utils.bash"
+
+main() {
+    # Check if config is already installed
+    if neovim_config_installed; then
+        echo "📂 config.nvim is already installed"
+        return 0
+    fi
+    
+    # Clone the configuration
+    clone_neovim_config
+    
+    # Restore plugins from lockfile
+    restore_neovim_plugins
+}
+
+# Only run main if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/lib/neovim-utils.bash
+++ b/lib/neovim-utils.bash
@@ -10,3 +10,21 @@ neovim_config_installed() {
     local config_dir="$HOME/Repos/ooloth/config.nvim"
     [ -d "$config_dir" ]
 }
+
+# Clone Neovim configuration repository
+clone_neovim_config() {
+    local repo="ooloth/config.nvim"
+    local local_repo="$HOME/Repos/$repo"
+    
+    echo "📂 Installing config.nvim"
+    
+    mkdir -p "$local_repo"
+    git clone "git@github.com:$repo.git" "$local_repo"
+}
+
+# Restore Neovim plugins from lockfile
+restore_neovim_plugins() {
+    echo "📂 Installing Lazy plugin versions from lazy-lock.json"
+    
+    NVIM_APPNAME=nvim-ide nvim --headless "+Lazy! restore" +qa
+}

--- a/lib/neovim-utils.bash
+++ b/lib/neovim-utils.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Neovim installation utilities
+# Provides functions for managing Neovim configuration
+
+set -euo pipefail
+
+# Check if Neovim config is installed
+neovim_config_installed() {
+    local config_dir="$HOME/Repos/ooloth/config.nvim"
+    [ -d "$config_dir" ]
+}

--- a/setup.bash
+++ b/setup.bash
@@ -109,6 +109,18 @@ main() {
         source homebrew.bash
     fi
     
+    if [[ -f "rust.bash" ]]; then
+        source rust.bash
+    fi
+    
+    if [[ -f "node.bash" ]]; then
+        source node.bash
+    fi
+    
+    if [[ -f "neovim.bash" ]]; then
+        source neovim.bash
+    fi
+    
     if [[ -f "symlinks.bash" ]]; then
         source symlinks.bash
     fi

--- a/test/install/test-neovim-installation.bats
+++ b/test/install/test-neovim-installation.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+# Test Neovim installation script
+
+setup() {
+    # Create temporary directory for each test
+    export TEST_TEMP_DIR
+    TEST_TEMP_DIR="$(mktemp -d)"
+    
+    # Save original environment
+    export ORIGINAL_HOME="$HOME"
+    export ORIGINAL_DOTFILES="${DOTFILES:-}"
+    export ORIGINAL_PATH="$PATH"
+    
+    # Set up test environment
+    export HOME="$TEST_TEMP_DIR/fake_home"
+    export DOTFILES="$TEST_TEMP_DIR/fake_dotfiles"
+    
+    # Create fake dotfiles structure
+    mkdir -p "$DOTFILES/lib"
+    cp "lib/neovim-utils.bash" "$DOTFILES/lib/"
+    
+    # Create mock bin directory
+    export MOCK_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$MOCK_BIN"
+}
+
+teardown() {
+    # Restore original environment
+    export HOME="$ORIGINAL_HOME"
+    export PATH="$ORIGINAL_PATH"
+    
+    if [[ -n "${ORIGINAL_DOTFILES}" ]]; then
+        export DOTFILES="$ORIGINAL_DOTFILES"
+    else
+        unset DOTFILES
+    fi
+    
+    # Clean up temporary directory
+    if [[ -n "${TEST_TEMP_DIR:-}" && -d "$TEST_TEMP_DIR" ]]; then
+        rm -rf "$TEST_TEMP_DIR"
+    fi
+}
+
+@test "neovim.bash exists and is executable" {
+    [ -f "$(pwd)/bin/install/neovim.bash" ]
+    [ -x "$(pwd)/bin/install/neovim.bash" ]
+}
+
+@test "neovim.bash skips installation when config already exists" {
+    # Create config directory
+    mkdir -p "$HOME/Repos/ooloth/config.nvim"
+    
+    run bash "$(pwd)/bin/install/neovim.bash"
+    
+    [[ "$output" =~ "config.nvim is already installed" ]]
+    [ "$status" -eq 0 ]
+}
+
+@test "neovim.bash clones config and restores plugins when not present" {
+    # Create mock git and nvim
+    cat > "$MOCK_BIN/git" << 'EOF'
+#!/bin/bash
+echo "git $@"
+if [[ "$1" == "clone" ]]; then
+    for arg in "$@"; do
+        target="$arg"
+    done
+    mkdir -p "$target"
+fi
+EOF
+    chmod +x "$MOCK_BIN/git"
+    
+    cat > "$MOCK_BIN/nvim" << 'EOF'
+#!/bin/bash
+echo "nvim $@"
+EOF
+    chmod +x "$MOCK_BIN/nvim"
+    
+    PATH="$MOCK_BIN:$PATH"
+    
+    run bash "$(pwd)/bin/install/neovim.bash"
+    
+    [[ "$output" =~ "Installing config.nvim" ]]
+    [[ "$output" =~ "git clone" ]]
+    [[ "$output" =~ "Installing Lazy plugin versions" ]]
+    [[ "$output" =~ "nvim --headless" ]]
+    [ "$status" -eq 0 ]
+    [ -d "$HOME/Repos/ooloth/config.nvim" ]
+}

--- a/test/install/test-neovim-utils.bats
+++ b/test/install/test-neovim-utils.bats
@@ -32,3 +32,62 @@ teardown() {
     run neovim_config_installed
     [ "$status" -eq 1 ]
 }
+
+@test "neovim_config_installed returns true when config exists" {
+    mkdir -p "$HOME/Repos/ooloth/config.nvim"
+    
+    run neovim_config_installed
+    [ "$status" -eq 0 ]
+}
+
+@test "clone_neovim_config clones the config repository" {
+    # Create mock git
+    local mock_bin="$TEST_TEMP_DIR/bin"
+    mkdir -p "$mock_bin"
+    
+    cat > "$mock_bin/git" << 'EOF'
+#!/bin/bash
+echo "git $@"
+if [[ "$1" == "clone" ]]; then
+    # Get the last argument (target directory)
+    for arg in "$@"; do
+        target="$arg"
+    done
+    # Create the target directory to simulate successful clone
+    mkdir -p "$target"
+fi
+EOF
+    chmod +x "$mock_bin/git"
+    
+    PATH="$mock_bin:$PATH"
+    
+    run clone_neovim_config
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Installing config.nvim" ]]
+    [[ "$output" =~ "git clone" ]]
+    [ -d "$HOME/Repos/ooloth/config.nvim" ]
+}
+
+@test "restore_neovim_plugins runs nvim headless command" {
+    # Create mock nvim
+    local mock_bin="$TEST_TEMP_DIR/bin"
+    mkdir -p "$mock_bin"
+    local log_file="$TEST_TEMP_DIR/nvim.log"
+    
+    cat > "$mock_bin/nvim" << EOF
+#!/bin/bash
+echo "nvim \$@" > "$log_file"
+EOF
+    chmod +x "$mock_bin/nvim"
+    
+    PATH="$mock_bin:$PATH"
+    
+    run restore_neovim_plugins
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Installing Lazy plugin versions" ]]
+    
+    # Check nvim was called with correct args
+    [[ -f "$log_file" ]]
+    grep -q "headless" "$log_file"
+    grep -q "Lazy! restore" "$log_file"
+}

--- a/test/install/test-neovim-utils.bats
+++ b/test/install/test-neovim-utils.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+# Test Neovim utility functions
+
+# Load the Neovim utilities
+load "../../lib/neovim-utils.bash"
+
+setup() {
+    # Create temporary directory for each test
+    export TEST_TEMP_DIR
+    TEST_TEMP_DIR="$(mktemp -d)"
+    
+    # Save original environment
+    export ORIGINAL_HOME="$HOME"
+    
+    # Set test HOME
+    export HOME="$TEST_TEMP_DIR/home"
+    mkdir -p "$HOME"
+}
+
+teardown() {
+    # Restore original environment
+    export HOME="$ORIGINAL_HOME"
+    
+    # Clean up temporary directory
+    if [[ -n "${TEST_TEMP_DIR:-}" && -d "$TEST_TEMP_DIR" ]]; then
+        rm -rf "$TEST_TEMP_DIR"
+    fi
+}
+
+@test "neovim_config_installed returns false when config not found" {
+    run neovim_config_installed
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## 💪 What
- **Files Created**: 
  - `lib/neovim-utils.bash` - Neovim utility functions (3 functions, 4 tests)
  - `bin/install/neovim.bash` - Bash replacement for neovim.zsh
  - `test/install/test-neovim-utils.bats` - 4 utility function tests
  - `test/install/test-neovim-installation.bats` - 3 integration tests
- **Files Updated**:
  - `setup.bash` - Added neovim.bash integration (along with rust.bash and node.bash from recent PRs)
- **Test Coverage**: 7 comprehensive tests covering all functionality
- **Quality**: 7/7 tests passing, zero shellcheck warnings

## 🤔 Why
- **Bash Migration**: Part of migration from custom zsh to industry-standard bash + shellcheck + bats
- **Professional Tooling**: Enables shellcheck linting and bats testing for Neovim installation
- **Shared Utilities**: Extracts reusable Neovim configuration logic
- **Plugin Management**: Includes Lazy plugin restoration from lockfile
- **Setup Integration**: Ensures parallel bash setup flow includes all migrated scripts

## 👀 Usage

**Run Neovim installation:**
```bash
./bin/install/neovim.bash
```

**Features:**
- Checks if config.nvim already cloned (skips if present)
- Clones ooloth/config.nvim repository via SSH
- Restores plugins from lazy-lock.json using headless Neovim
- Uses NVIM_APPNAME=nvim-ide for proper configuration

## 👩‍🔬 How to validate

**Run utility tests:**
```bash
bats test/install/test-neovim-utils.bats
```

**Run integration tests:**
```bash
bats test/install/test-neovim-installation.bats
```

**Expected output (7 tests total):**
```
# Utility tests
1..4
ok 1 neovim_config_installed returns false when config not found
ok 2 neovim_config_installed returns true when config exists
ok 3 clone_neovim_config clones the config repository
ok 4 restore_neovim_plugins runs nvim headless command

# Integration tests
1..3
ok 1 neovim.bash exists and is executable
ok 2 neovim.bash skips installation when config already exists
ok 3 neovim.bash clones config and restores plugins when not present
```

**Verify shellcheck compliance:**
```bash
shellcheck lib/neovim-utils.bash bin/install/neovim.bash setup.bash
```

**Verify setup.bash integration:**
```bash
grep -A 20 "rust.bash" setup.bash
```

## Architecture

**Functions Provided:**
- `neovim_config_installed()` - Checks if config.nvim exists
- `clone_neovim_config()` - Clones configuration repository
- `restore_neovim_plugins()` - Restores plugins from lockfile

**Key Features:**
- **Config Management**: Clones personal Neovim configuration
- **Plugin Restoration**: Uses Lazy.nvim's restore feature
- **Idempotent**: Skips if already installed
- **Headless Operation**: No UI required for plugin installation

## Setup Integration (setup.bash updates)

**Added missing bash scripts from recent PRs:**
- `rust.bash` integration (from PR 23)
- `node.bash` integration (from PR 24)
- `neovim.bash` integration (from PR 25)

This ensures the parallel bash setup flow includes all migrated installation scripts in the correct order, maintaining the bash migration strategy of building a complete alternative to the zsh setup flow.

## 🔗 Related links
- [Bash Migration Epic](https://github.com/ooloth/dotfiles/blob/main/.claude/tasks/2025-07-07-bash-migration.md)
- [Original neovim.zsh](https://github.com/ooloth/dotfiles/blob/main/bin/install/neovim.zsh)
- [Lazy.nvim Documentation](https://github.com/folke/lazy.nvim) - Plugin manager

## Implementation Details

**TDD Approach:**
- 7 test cases following strict TDD methodology
- Comprehensive mocking for git and nvim commands
- Both unit and integration test coverage
- Behavioral testing focus

**Migration Benefits:**
- Professional tooling (shellcheck + bats)
- Better error handling with strict mode
- Comprehensive test coverage
- Easier maintenance