### PR TITLE
Improve pr-draft formatting guidance for Related links section

### DIFF
--- a/home/.claude/commands/pr-draft.md
+++ b/home/.claude/commands/pr-draft.md
@@ -31,13 +31,13 @@ Create a draft pull request from the current branch to the main branch.
      - 🤔 **Why**: Problem solved, business value, timing rationale
      - 👀 **Usage**: How to use new functionality (if user-facing)
      - 👩‍🔬 **How to validate**: Manual steps for reviewers to exercise the code and observe outcomes (teach reviewers how to prove the changes work by using the functionality - never tell them to run tests or checks, as CI handles that)
-     - 🔗 **Related links**: External context with real URLs (only if valuable, omit if none)
+     - 🔗 **Related links**: External context as markdown links (only if valuable, omit if none)
    - **Append missing valuable sections** from the high-quality template if not covered by project template
    - **Focus on reviewer experience** - provide context that helps reviewers understand and validate changes
    - **"What" vs "Why" clarity**: "What" describes direct changes/impacts, "Why" explains benefits and rationale
    - **Format requirements**: Start "What" with flat bullet list of primary behavior changes/takeaways, format "Why" as flat bullet list
    - **Avoid file listings**: Don't include "New Files" sections - reviewers will see files in the PR, focus on what the PR accomplishes
-   - **Link formatting**: Use markdown links for external URLs, raw URLs for GitHub PRs/issues (GitHub formats them nicely)
+   - **Link formatting**: Use markdown links for external URLs, raw URLs for GitHub PRs/issues (GitHub formats them nicely), format Related links as bullet list
    - **"Why" tone**: Make salient points about why changes help this specific project, avoid overly broad statements or overselling
    - **Reference related issues/plans** - link to GitHub issues, project plans, or task files this PR addresses
 9. Create the draft PR with descriptive title and structured body


### PR DESCRIPTION
## 💪 What

- Updated `pr-draft.md` to specify markdown links instead of bare URLs for Related links section
- Added guidance to format Related links as bullet list
- Clarified link formatting expectations in the command documentation

## 🤔 Why

- Previous PR (#30) used bare URL instead of descriptive markdown link in Related links
- Bullet list format makes multiple links easier to scan and read
- Consistent formatting improves reviewer experience across all PRs created with this command

## 👩‍🔬 How to validate

1. Use `/pr-draft` command to create a new PR
2. Verify the Related links section uses markdown link format: `[descriptive text](URL)`
3. Confirm links are formatted as bullet list when multiple links are present
4. Check that external URLs have descriptive text rather than bare URLs

## 🔗 Related links

- [Claude Code slash commands documentation](https://docs.anthropic.com/en/docs/claude-code/slash-commands)