### PR TITLE
Streamline PR workflow guidance between CLAUDE.md and slash commands

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -301,179 +301,32 @@ assert_not_equals(0, exit_code, "setup should exit when prerequisites fail")
 
 ### PR Creation Requirements
 
-**CRITICAL: Always create PRs in draft mode for review workflows:**
+For detailed PR creation workflow, use the `/pr-draft` command.
 
-1. **Default to draft mode** - Use `gh pr create --draft` when creating PRs
-2. **Draft allows iteration** - User can review and request changes before marking ready
-3. **Prevents premature merge** - Ensures proper review process is followed
-4. **Only use non-draft PRs** when explicitly instructed or for trivial changes
-5. **Mark ready when told** - User will explicitly say when to convert from draft to ready
+Key principles:
+- Always create PRs in draft mode for review workflows
+- Use structured PR templates for clear communication
+- Focus on complete functionality bundles
+- Include tests, implementation, and documentation together
 
-**Example PR creation:**
-```bash
-gh pr create --draft --title "Feature Title" --body "$(cat <<'EOF'
-[PR description using template]
-EOF
-)"
-```
+See `/pr-draft` command for complete workflow, template guidelines, and sizing recommendations.
 
-### PR Template Usage
+### PR Workflow Requirements
 
-**Always use the high-quality PR template when repositories lack good templates:**
+**CRITICAL commit and push behavior:**
+- Commit and push changes immediately after making them
+- Update PR description after pushing commits with new functionality
+- Never consider PRs "done" until actually merged
+- Stay focused on current PR until user confirms completion
 
-1. **For repos without PR templates** - Use the reference template from `~/.claude/PR_TEMPLATE_REFERENCE.md`
-2. **For repos with overly brief templates** (e.g., just "What" and "Why") - Enhance with the spirit of the reference template
-3. **Bring the template philosophy**: Focus on What/Why/Usage/Validation/Links structure
-4. **Maintain reviewer focus**: Emphasize "How to validate" as teaching tool for reviewers
-5. **Include context**: Always provide related links that help reviewers understand background
+**Key principles:**
+- User expects to see changes in GitHub UI immediately
+- All commits must be explained in PR descriptions
+- Include off-topic commits transparently
+- Wait for user direction before considering PR work finished
 
-**Reference template structure:**
-- 💪 What: What's new/different, files changed, testing/documentation
-- 🤔 Why: Problem solved, business value, timing rationale  
-- 👀 Usage: How to use new functionality (optional for user-facing changes)
-- 👩‍🔬 How to validate: Manual steps for reviewers to confirm changes work
-- 🔗 Related links: External context that helps reviewers understand background
+See `/pr-draft` and `/pr-review` commands for detailed workflow guidance.
 
-**Related links guidelines:**
-- **ONLY include links that provide valuable context NOT already in the PR**
-- **External references**: Documentation, Stack Overflow, RFCs, design docs, external issues
-- **Background PRs**: Previous/related PRs that provide important context
-- **DO NOT include**:
-  - Files in the current PR (reviewers can already see them)
-  - Generic/empty pages (issues page with no relevant issues)
-  - Links that duplicate information already in PR description
-  - Internal project files unless they provide critical background context
-- **If no useful links exist, omit the entire Related links section** - no section is better than empty section
-- **Quality over quantity** - 1-2 highly relevant links better than 5 marginally useful ones
-
-**When to apply:**
-- Creating PRs in repos without templates
-- Repos with minimal templates missing key sections
-- Any time PR description would benefit from structured approach
-- Use good judgment - don't force inappropriate structure on simple fixes
-
-### PR Size and Focus Guidelines
-
-**Each PR should be a complete bundle of one new behavior:**
-
-1. **Complete functionality** - Include tests, implementation, and actual usage together
-2. **Avoid dead code** - Don't add functions/utilities without demonstrating their use
-3. **Include documentation updates** - Update code comments, READMEs, CLAUDE.md as needed
-4. **One responsibility per PR** - Each PR should do exactly one thing, but do it completely
-
-**Size guidelines:**
-- **Target < 100 lines** when possible for easy review
-- **Accept larger PRs (200-400+ lines)** when needed for completeness
-- **Better to have one complete 300-line PR** than three 100-line PRs with dead code
-- **Size is secondary to completeness and logical boundaries**
-
-**Examples of complete behavior bundles:**
-- ✅ "Add Homebrew detection with tests and integration into installation script"
-- ✅ "Add API validation with tests, error messages, and documentation"
-- ✅ "Add database migration with rollback functionality and admin tools"
-- ❌ "Add Homebrew detection utility" (missing actual usage)
-- ❌ "Add authentication tests" (missing implementation and integration)
-
-**For projects with separate frontend/backend deployments:**
-- ✅ Backend PR: "Add user authentication API endpoints with tests and documentation"
-- ✅ Frontend PR: "Add login UI components using new authentication endpoints" 
-- ✅ Backend PR: "Remove deprecated login endpoints after frontend migration"
-- ❌ "Add user authentication with backend API and frontend UI" (deployment complexity)
-
-**When to split PRs:**
-- **Multiple unrelated behaviors** (authentication vs database vs caching)
-- **Different deployment boundaries** (frontend vs backend in systems with separate deployment pipelines)
-- **Refactoring separate from new features** (clean up existing code vs add new functionality)
-- **Infrastructure changes that enable multiple future features** (but include at least one usage example)
-
-**Deployment-aware PR sequencing:**
-- **Backend-first approach**: Deploy backend changes before frontend changes that depend on them
-- **Graceful migrations**: When replacing functionality, deploy new approach → migrate frontend → remove old approach
-- **Feature flags**: Use feature toggles when backend and frontend changes must be deployed together
-- **Backward compatibility**: Ensure backend changes don't break existing frontend functionality
-
-**Complete behavior includes:**
-- ✅ Tests that validate the behavior works
-- ✅ Implementation that passes the tests
-- ✅ Integration/usage that demonstrates real-world value
-- ✅ Documentation updates for user-facing changes
-- ✅ Code comments for complex logic
-- ✅ **Only code that is actually used** - no speculative "might be useful" functions
-
-### PR Description Maintenance
-
-**Always update the PR description after new commits** that change what the PR includes:
-
-- After you push new commits, update the PR description with available tools
-- After the user pushes commits, check what changed and update the description
-- Keep the "Changes" section current with all modifications
-- Update test plans if new tests were added
-- Add new commits to the implementation approach if significant
-
-### PR Commit Pushing and Description Updates
-
-**Always commit and push changes immediately after making them:**
-
-1. **After making any file changes** - Commit immediately, don't accumulate changes
-2. **After making commits to a PR branch** - Push immediately so changes are visible in GitHub
-3. **Don't batch multiple commits** before pushing - push after each commit or small group
-4. **User expects to see changes in GitHub UI** when you announce commits in terminal
-5. **Prevents confusion** between what's committed locally vs what's visible for review
-6. **Automatic behavior** - Commit and push should be automatic, not requiring explicit user request
-
-**CRITICAL: PRs are not complete until merged:**
-
-- **Never consider a PR "done" or "completed" until it's actually merged**
-- **Don't move to next tasks** while a PR is still open and being iterated on
-- **Stay focused on current PR** until user explicitly says to move on or confirms merge
-- **PR work includes** creation, iteration, addressing feedback, and final merge
-- **Wait for user direction** before considering PR work finished
-- **Never mark PR tasks as completed in todo lists** until the PR is actually merged
-- **Don't update project roadmaps or task trackers** to show PR completion until merge is confirmed
-
-**CRITICAL: Always update PR description after pushing commits with new functionality:**
-
-1. **Check if new commits add functionality** not already described in the PR
-2. **Update PR description immediately** after pushing if commits introduce:
-   - New features or capabilities not mentioned
-   - Additional test coverage or edge cases
-   - Refactoring or code improvements
-   - Documentation updates (like CLAUDE.md changes)
-   - Bug fixes or dead code removal
-   - **ANY commits, even off-topic ones** - all commits must be explained for reviewers
-3. **Use `gh pr edit [number] --body "..."` or web interface** to update
-4. **Don't assume changes are obvious** - explicitly document what was added
-5. **Include off-topic commits transparently** - clearly separate them but don't hide them
-
-Example workflow:
-```
-# When making any file changes during development
-[make file changes]
-git add [files]
-git commit -m "descriptive commit message"
-git push origin feature-branch  # ← CRITICAL: Always push immediately
-
-# ← CRITICAL: Update PR description if commits add new functionality
-gh pr edit [number] --body "$(cat <<'EOF'
-[updated description with new changes]
-EOF
-)"
-```
-
-**This workflow should be automatic - don't wait for user to ask "commit and push":**
-- When you make file changes, immediately commit and push
-- When you improve documentation, immediately commit and push  
-- When you fix code issues, immediately commit and push
-- The user expects to see changes in GitHub without having to request it
-
-**Handling off-topic commits in PR descriptions:**
-- **Always include all commits** - even those not related to the PR's main purpose
-- **Use clear section separation** - e.g., "Documentation Updates (Claude Development Process)"
-- **Provide context** - explain why off-topic changes are included (e.g., "discovered during development")
-- **Be transparent** - better to over-explain than leave reviewers wondering
-- **Example structure**: Core functionality sections first, then clearly labeled off-topic sections
-
-**Exception**: Only skip pushing if explicitly told not to push or if you're about to make several rapid commits in succession (then push the batch).
 
 ### Multi-PR Task Management
 

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -299,6 +299,34 @@ assert_not_equals(0, exit_code, "setup should exit when prerequisites fail")
 - Split large changes into multiple PRs when possible
 - Include context about why changes were made, not just what changed
 
+### PR Size and Focus Guidelines
+
+**Each PR should be a complete bundle of one new behavior:**
+
+1. **Complete functionality** - Include tests, implementation, and actual usage together
+2. **Avoid dead code** - Don't add functions/utilities without demonstrating their use
+3. **Include documentation updates** - Update code comments, READMEs, CLAUDE.md as needed
+4. **One responsibility per PR** - Each PR should do exactly one thing, but do it completely
+
+**Size guidelines:**
+- **Target < 100 lines** when possible for easy review
+- **Accept larger PRs (200-400+ lines)** when needed for completeness
+- **Better to have one complete 300-line PR** than three 100-line PRs with dead code
+- **Size is secondary to completeness and logical boundaries**
+
+**Examples of complete behavior bundles:**
+- ✅ "Add Homebrew detection with tests and integration into installation script"
+- ✅ "Add API validation with tests, error messages, and documentation"
+- ✅ "Add database migration with rollback functionality and admin tools"
+- ❌ "Add Homebrew detection utility" (missing actual usage)
+- ❌ "Add authentication tests" (missing implementation and integration)
+
+**When to split PRs:**
+- **Multiple unrelated behaviors** (authentication vs database vs caching)
+- **Different deployment boundaries** (frontend vs backend in systems with separate deployment pipelines)
+- **Refactoring separate from new features** (clean up existing code vs add new functionality)
+- **Infrastructure changes that enable multiple future features** (but include at least one usage example)
+
 ### PR Creation Requirements
 
 For detailed PR creation workflow, use the `/pr-draft` command.
@@ -306,10 +334,9 @@ For detailed PR creation workflow, use the `/pr-draft` command.
 Key principles:
 - Always create PRs in draft mode for review workflows
 - Use structured PR templates for clear communication
-- Focus on complete functionality bundles
-- Include tests, implementation, and documentation together
+- Focus on complete functionality bundles (see sizing guidelines above)
 
-See `/pr-draft` command for complete workflow, template guidelines, and sizing recommendations.
+See `/pr-draft` command for complete workflow and template guidelines.
 
 ### PR Workflow Requirements
 

--- a/home/.claude/commands/pr-draft.md
+++ b/home/.claude/commands/pr-draft.md
@@ -59,15 +59,6 @@ Create a draft pull request from the current branch to the main branch.
 - Any time PR description would benefit from structured approach
 - Use good judgment - don't force inappropriate structure on simple fixes
 
-**PR Size and Focus Guidelines:**
-- **Complete functionality** - Include tests, implementation, and actual usage together
-- **Avoid dead code** - Don't add functions/utilities without demonstrating their use
-- **Include documentation updates** - Update code comments, READMEs, CLAUDE.md as needed
-- **One responsibility per PR** - Each PR should do exactly one thing, but do it completely
-- **Target < 100 lines** when possible for easy review
-- **Accept larger PRs (200-400+ lines)** when needed for completeness
-- **Better to have one complete 300-line PR** than three 100-line PRs with dead code
-
 **Draft mode requirements:**
 - **Always create PRs in draft mode** for review workflows
 - **Draft allows iteration** - User can review and request changes before marking ready

--- a/home/.claude/commands/pr-draft.md
+++ b/home/.claude/commands/pr-draft.md
@@ -40,6 +40,40 @@ Create a draft pull request from the current branch to the main branch.
    - **Link formatting**: Use markdown links for external URLs, raw URLs for GitHub PRs/issues (GitHub formats them nicely), format Related links as bullet list
    - **"Why" tone**: Make salient points about why changes help this specific project, avoid overly broad statements or overselling
    - **Reference related issues/plans** - link to GitHub issues, project plans, or task files this PR addresses
+
+**Related links guidelines:**
+- **ONLY include links that provide valuable context NOT already in the PR**
+- **External references**: Documentation, Stack Overflow, RFCs, design docs, external issues
+- **Background PRs**: Previous/related PRs that provide important context
+- **DO NOT include**:
+  - Files in the current PR (reviewers can already see them)
+  - Generic/empty pages (issues page with no relevant issues)
+  - Links that duplicate information already in PR description
+  - Internal project files unless they provide critical background context
+- **If no useful links exist, omit the entire Related links section** - no section is better than empty section
+- **Quality over quantity** - 1-2 highly relevant links better than 5 marginally useful ones
+
+**When to apply template:**
+- Creating PRs in repos without templates
+- Repos with minimal templates missing key sections
+- Any time PR description would benefit from structured approach
+- Use good judgment - don't force inappropriate structure on simple fixes
+
+**PR Size and Focus Guidelines:**
+- **Complete functionality** - Include tests, implementation, and actual usage together
+- **Avoid dead code** - Don't add functions/utilities without demonstrating their use
+- **Include documentation updates** - Update code comments, READMEs, CLAUDE.md as needed
+- **One responsibility per PR** - Each PR should do exactly one thing, but do it completely
+- **Target < 100 lines** when possible for easy review
+- **Accept larger PRs (200-400+ lines)** when needed for completeness
+- **Better to have one complete 300-line PR** than three 100-line PRs with dead code
+
+**Draft mode requirements:**
+- **Always create PRs in draft mode** for review workflows
+- **Draft allows iteration** - User can review and request changes before marking ready
+- **Prevents premature merge** - Ensures proper review process is followed
+- **Only use non-draft PRs** when explicitly instructed or for trivial changes
+
 9. Create the draft PR with descriptive title and structured body
 
 **GitHub CLI commands to use:**


### PR DESCRIPTION
## 💪 What

- Enhanced `/pr-draft` command with tactical PR creation guidance from CLAUDE.md
- Added detailed sections: related links guidelines, template application guidance, draft mode requirements
- Moved PR Size and Focus Guidelines back to CLAUDE.md as strategic planning guidance (consulted during task scoping)
- Streamlined CLAUDE.md PR creation sections to reference `/pr-draft` for tactical workflow
- Created clear separation: strategic planning in CLAUDE.md, tactical execution in slash commands

## 🤔 Why

- Follows same pattern established with `/tdd` command consolidation
- PR sizing guidelines are strategic planning decisions made during task breakdown, not tactical PR creation steps
- Template and formatting guidance needed immediately during PR creation workflow
- Eliminates context switching for tactical steps while keeping strategic guidance accessible
- Makes `/pr-draft` focused on execution, CLAUDE.md focused on planning and principles

## 👀 Usage

**Strategic planning (CLAUDE.md):**
- PR Size and Focus Guidelines - consulted when scoping work and deciding PR boundaries
- Examples of complete behavior bundles and when to split PRs
- High-level principles for work organization

**Tactical execution (`/pr-draft`):**
- Related links guidelines (what to include/exclude)
- Template application guidance and when to apply
- Draft mode requirements and workflow steps
- All immediate guidance needed during PR creation

## 👩‍🔬 How to validate

1. Use `/pr-draft` command and verify all tactical guidance is immediately available
2. Confirm PR sizing guidance remains in CLAUDE.md for strategic planning
3. Check clear separation between planning (CLAUDE.md) and execution (slash commands)
4. Verify no duplication between the two locations
5. Test that workflow feels efficient with appropriate guidance at each stage

## 🔗 Related links

- [Claude Code slash commands documentation](https://docs.anthropic.com/en/docs/claude-code/slash-commands)