### PR TITLE
feat: add feature discovery to setup.bash

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -11,6 +11,28 @@ set -euo pipefail
 # Set up environment
 export DOTFILES="$HOME/Repos/ooloth/dotfiles"
 
+# Feature discovery function
+# Tries new feature location first, falls back to old location
+run_installer() {
+    local feature_name="$1"
+    local feature_path="$DOTFILES/features/$feature_name/install.bash"
+    local legacy_path="$feature_name.bash"
+    
+    # Try new feature location first
+    if [[ -f "$feature_path" ]]; then
+        printf "  → Using feature-based installer: %s\n" "$feature_path"
+        source "$feature_path"
+    # Fall back to old location
+    elif [[ -f "$legacy_path" ]]; then
+        printf "  → Using legacy installer: %s\n" "$legacy_path"
+        source "$legacy_path"
+    else
+        printf "  ⚠️  No installer found for %s\n" "$feature_name"
+        # Don't fail, just warn
+        return 0
+    fi
+}
+
 # Main installation function
 main() {
     printf "\nWelcome to your new Mac! This installation will perform the following steps:\n\n"
@@ -97,57 +119,20 @@ main() {
     cd "$DOTFILES/bin/install"
 
     # Run bash installation scripts if they exist
-    if [[ -f "ssh.bash" ]]; then
-        source ssh.bash
-    fi
-
-    if [[ -f "github.bash" ]]; then
-        source github.bash
-    fi
-
-    if [[ -f "homebrew.bash" ]]; then
-        source homebrew.bash
-    fi
-
-    if [[ -f "zsh.bash" ]]; then
-        source zsh.bash
-    fi
-
-    if [[ -f "rust.bash" ]]; then
-        source rust.bash
-    fi
-
-    if [[ -f "uv.bash" ]]; then
-        source uv.bash
-    fi
-
-    if [[ -f "node.bash" ]]; then
-        source node.bash
-    fi
-
-    if [[ -f "neovim.bash" ]]; then
-        source neovim.bash
-    fi
-
-    if [[ -f "tmux.bash" ]]; then
-        source tmux.bash
-    fi
-
-    if [[ -f "content.bash" ]]; then
-        source content.bash
-    fi
-
-    if [[ -f "yazi.bash" ]]; then
-        source yazi.bash
-    fi
-
-    if [[ -f "symlinks.bash" ]]; then
-        source symlinks.bash
-    fi
-
-    if [[ -f "settings.bash" ]]; then
-        source settings.bash
-    fi
+    # Run installers using feature discovery
+    run_installer "ssh"
+    run_installer "github"
+    run_installer "homebrew"
+    run_installer "zsh"
+    run_installer "rust"
+    run_installer "uv"
+    run_installer "node"
+    run_installer "neovim"
+    run_installer "tmux"
+    run_installer "content"
+    run_installer "yazi"
+    run_installer "symlinks"
+    run_installer "settings"
 
     # TODO: Add remaining installation scripts as they are migrated to bash
 

--- a/test/setup/test-feature-discovery.bats
+++ b/test/setup/test-feature-discovery.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# Test feature discovery functionality in setup.bash
+# Verifies that both old and new paths are discovered correctly
+
+setup() {
+    # Save current directory
+    export ORIGINAL_PWD="$PWD"
+    export ORIGINAL_DOTFILES="${DOTFILES:-}"
+    
+    # Create test directory structure
+    export TEST_DIR="$(mktemp -d)"
+    export DOTFILES="$TEST_DIR/dotfiles"
+    
+    # Create mock dotfiles structure
+    mkdir -p "$DOTFILES/bin/install"
+    mkdir -p "$DOTFILES/features/ssh"
+    mkdir -p "$DOTFILES/features/git"
+    
+    # Change to install directory (as setup.bash does)
+    cd "$DOTFILES/bin/install"
+}
+
+teardown() {
+    # Restore directory and environment
+    cd "$ORIGINAL_PWD" || true
+    if [[ -n "$ORIGINAL_DOTFILES" ]]; then
+        export DOTFILES="$ORIGINAL_DOTFILES"
+    else
+        unset DOTFILES
+    fi
+    
+    # Clean up test directory
+    rm -rf "$TEST_DIR"
+}
+
+# Source the run_installer function from setup.bash
+load_run_installer() {
+    # Extract just the run_installer function from setup.bash
+    sed -n '/^run_installer()/,/^}/p' "$ORIGINAL_PWD/setup.bash" > "$TEST_DIR/run_installer.bash"
+    source "$TEST_DIR/run_installer.bash"
+}
+
+@test "run_installer: prefers feature location over legacy location" {
+    load_run_installer
+    
+    # Create both locations
+    echo 'echo "FEATURE"' > "$DOTFILES/features/ssh/install.bash"
+    echo 'echo "LEGACY"' > "ssh.bash"
+    
+    # Should use feature location
+    output=$(run_installer "ssh" 2>&1)
+    [[ "$output" == *"Using feature-based installer"* ]]
+    [[ "$output" == *"FEATURE"* ]]
+    [[ "$output" != *"LEGACY"* ]]
+}
+
+@test "run_installer: falls back to legacy location when feature missing" {
+    load_run_installer
+    
+    # Create only legacy location
+    echo 'echo "LEGACY"' > "github.bash"
+    
+    # Should use legacy location
+    output=$(run_installer "github" 2>&1)
+    [[ "$output" == *"Using legacy installer"* ]]
+    [[ "$output" == *"LEGACY"* ]]
+}
+
+@test "run_installer: handles missing installer gracefully" {
+    load_run_installer
+    
+    # Don't create any installer
+    output=$(run_installer "missing" 2>&1)
+    [[ "$output" == *"No installer found for missing"* ]]
+}
+
+@test "run_installer: shows correct paths in output" {
+    load_run_installer
+    
+    # Create feature location
+    echo 'echo "TEST"' > "$DOTFILES/features/git/install.bash"
+    
+    # Check path is shown
+    output=$(run_installer "git" 2>&1)
+    [[ "$output" == *"$DOTFILES/features/git/install.bash"* ]]
+}
+
+@test "SSH uses feature location when available" {
+    load_run_installer
+    
+    # Verify SSH is in features
+    echo 'echo "SSH FEATURE"' > "$DOTFILES/features/ssh/install.bash"
+    
+    output=$(run_installer "ssh" 2>&1)
+    [[ "$output" == *"Using feature-based installer"* ]]
+    [[ "$output" == *"SSH FEATURE"* ]]
+}


### PR DESCRIPTION
## Summary

This PR adds feature discovery to setup.bash, enabling it to automatically find and use features from the new `/features/` directory while maintaining backwards compatibility with the old structure.

## Changes

- Added `run_installer()` function that prefers feature-based locations
- Updated all installer calls to use feature discovery
- Added logging to show which path is being used
- Added comprehensive tests for discovery behavior

## Feature Discovery Logic

1. **Try feature location first**: `features/{name}/install.bash`
2. **Fall back to legacy**: `{name}.bash` (in bin/install/)
3. **Graceful handling**: Warns if neither exists but continues

## Testing

All feature discovery tests pass:
```bash
bats test/setup/test-feature-discovery.bats
# 5/5 tests pass
```

The tests verify:
- ✅ Feature location preferred over legacy
- ✅ Fallback to legacy when feature missing  
- ✅ Graceful handling of missing installers
- ✅ Correct path logging
- ✅ SSH uses feature location

## Benefits

- **Backwards compatible**: Existing system continues to work
- **Progressive migration**: Can migrate features incrementally
- **Clear visibility**: Logs show which path is being used
- **No symlinks needed**: Direct path resolution

## Example Output

```
  → Using feature-based installer: /path/to/dotfiles/features/ssh/install.bash
  → Using legacy installer: github.bash
  ⚠️  No installer found for missing-feature
```

## Next Steps

With feature discovery in place, we can now migrate more features to the new structure. SSH already benefits from this change.

Relates to #43