### PR TITLE
refactor: migrate bash utilities to core directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,5 +128,20 @@ find test/ -name "test-*.zsh" -perm +111 | grep -v "lib/" | grep -v "run-tests.z
 
 The numbers should match to ensure no test files are being missed.
 
+### Shellcheck Standards
+
+**IMPORTANT: Always use `.shellcheckrc` for configuration, never inline comments**
+
+When working with bash scripts in this repository:
+
+1. **Fix issues, don't ignore them** - If shellcheck reports an issue, fix the code rather than adding ignore directives
+2. **Use `.shellcheckrc` for project-wide settings** - All shellcheck configuration should be centralized in the `.shellcheckrc` file
+3. **Never use inline shellcheck directives** - Don't add comments like `# shellcheck disable=SC2155`
+4. **Common fixes**:
+   - SC2155: Separate variable declaration from assignment when using command substitution
+   - Example: Change `local var="$(command)"` to `local var` then `var="$(command)"`
+
+All bash scripts must pass shellcheck with zero warnings before merging.
+
 ### Project-Specific Git Ignore
 Use the `.gitignore` file and not the `config/git/ignore` file when adding project-specific ignore rules.

--- a/core/detection/machine.bash
+++ b/core/detection/machine.bash
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Machine detection utilities for dotfiles setup
+# Dynamically detects machine type based on hostname patterns
+
+set -euo pipefail
+
+# Detect machine type based on hostname
+detect_machine_type() {
+    # Check for environment variable override first
+    if [[ -n "${MACHINE:-}" ]]; then
+        echo "$MACHINE"
+        return 0
+    fi
+    
+    # Get hostname for detection
+    local hostname
+    if command -v hostname >/dev/null 2>&1; then
+        hostname=$(hostname)
+    else
+        # Fallback if hostname command is not available
+        hostname="${HOST:-unknown}"
+    fi
+    
+    # Pattern matching for machine types
+    case "$hostname" in
+        *Air*)
+            echo "air"
+            ;;
+        *Mini*)
+            echo "mini"
+            ;;
+        *)
+            # Default to work for unknown hostnames
+            echo "work"
+            ;;
+    esac
+}
+
+# Set machine-specific environment variables based on detected type
+set_machine_variables() {
+    local machine_type="$1"
+    
+    # Reset all machine variables
+    export IS_AIR=false
+    export IS_MINI=false
+    export IS_WORK=false
+    
+    # Set the appropriate variable based on machine type
+    case "$machine_type" in
+        "air")
+            export IS_AIR=true
+            export MACHINE="air"
+            ;;
+        "mini")
+            export IS_MINI=true
+            export MACHINE="mini"
+            ;;
+        *)
+            # Default to work for unknown types (including explicit "work")
+            export IS_WORK=true
+            export MACHINE="work"
+            ;;
+    esac
+}
+
+# Initialize machine detection and set variables
+init_machine_detection() {
+    local detected_type
+    detected_type=$(detect_machine_type)
+    set_machine_variables "$detected_type"
+    
+    # Optional: print detection result for debugging
+    if [[ "${DEBUG_MACHINE_DETECTION:-false}" == "true" ]]; then
+        echo "Detected machine type: $MACHINE" >&2
+    fi
+}

--- a/core/dry-run/utils.bash
+++ b/core/dry-run/utils.bash
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Dry-run utilities for dotfiles setup
+# Provides read-only validation and logging capabilities
+
+set -euo pipefail
+
+# Parse command line arguments for dry-run flags
+parse_dry_run_flags() {
+    # Default to false
+    export DRY_RUN="false"
+    
+    # Check all arguments for --dry-run flag
+    for arg in "$@"; do
+        if [[ "$arg" == "--dry-run" ]]; then
+            export DRY_RUN="true"
+            break
+        fi
+    done
+}
+
+# Log actions in dry-run mode without executing them
+dry_run_log() {
+    local action="${1:-}"
+    
+    if [[ -z "$action" ]]; then
+        echo "Error: No action provided to dry_run_log" >&2
+        return 1
+    fi
+    
+    # Always log the action with DRY RUN prefix
+    echo "DRY RUN: $action"
+    
+    # In dry-run mode, we don't execute the action
+    return 0
+}
+
+# Execute commands conditionally based on dry-run mode
+dry_run_execute() {
+    local command="${1:-}"
+    
+    if [[ -z "$command" ]]; then
+        echo "Error: No command provided to dry_run_execute" >&2
+        return 1
+    fi
+    
+    # Check if we're in dry-run mode
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        # In dry-run mode, just log the command
+        dry_run_log "$command"
+        return 0
+    else
+        # In normal mode, execute the command
+        eval "$command"
+        return $?
+    fi
+}

--- a/core/errors/handling.bash
+++ b/core/errors/handling.bash
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# Error handling utilities for dotfiles setup
+# Provides graceful error handling and recovery mechanisms
+
+set -euo pipefail
+
+# Capture and handle command errors with context
+capture_error() {
+    local command="${1:-}"
+    local context="${2:-Command execution}"
+    local exit_code
+    local output
+    
+    if [[ -z "$command" ]]; then
+        echo "Error: No command provided to capture_error" >&2
+        return 1
+    fi
+    
+    # Execute the command and capture output
+    output=$(eval "$command" 2>&1)
+    exit_code=$?
+    
+    # Show the output first (if any)
+    if [[ -n "$output" ]]; then
+        echo "$output"
+    fi
+    
+    # Check if command failed
+    if [[ $exit_code -ne 0 ]]; then
+        echo "Error: $context failed (exit code: $exit_code)" >&2
+        echo "Command: $command" >&2
+        return $exit_code
+    fi
+    
+    return 0
+}
+
+# Retry a command with exponential backoff
+retry_with_backoff() {
+    local command="${1:-}"
+    local max_attempts="${2:-3}"
+    local initial_delay="${3:-1}"
+    local attempt=1
+    local delay=$initial_delay
+    
+    if [[ -z "$command" ]]; then
+        echo "Error: No command provided to retry_with_backoff" >&2
+        return 1
+    fi
+    
+    while [[ $attempt -le $max_attempts ]]; do
+        # Try the command
+        if eval "$command" 2>/dev/null; then
+            return 0
+        fi
+        
+        # If we've exhausted attempts, fail
+        if [[ $attempt -eq $max_attempts ]]; then
+            echo "Error: Command failed after $max_attempts attempts" >&2
+            echo "Command: $command" >&2
+            return 1
+        fi
+        
+        # Wait before retry with exponential backoff
+        echo "Attempt $attempt failed, retrying in ${delay}s..." >&2
+        sleep "$delay"
+        
+        # Increase delay for next attempt
+        delay=$((delay * 2))
+        ((attempt++))
+    done
+}
+
+# Provide user-friendly error messages with helpful suggestions
+handle_error() {
+    local command="${1:-}"
+    local error_code="${2:-}"
+    local error_message="${3:-Unknown error}"
+    
+    if [[ -z "$command" ]]; then
+        echo "Error: No command provided to handle_error" >&2
+        return 1
+    fi
+    
+    echo "❌ Error occurred while running: $command" >&2
+    echo "   Error: $error_message" >&2
+    
+    # Provide helpful suggestions based on error type
+    case "$error_code" in
+        "EACCES"|"EPERM")
+            echo "   💡 Suggestion: Try running with sudo or check file permissions" >&2
+            ;;
+        "ENOENT")
+            echo "   💡 Suggestion: Check if the file or directory exists" >&2
+            ;;
+        "ECONNREFUSED"|"ETIMEDOUT")
+            echo "   💡 Suggestion: Check your internet connection or try again later" >&2
+            ;;
+        "ENOSPC")
+            echo "   💡 Suggestion: Free up disk space and try again" >&2
+            ;;
+        *)
+            echo "   💡 Suggestion: Check the command syntax and try again" >&2
+            ;;
+    esac
+    
+    return 1
+}

--- a/core/prerequisites/validation.bash
+++ b/core/prerequisites/validation.bash
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# Prerequisite validation utilities for dotfiles setup
+# Validates system requirements before installation begins
+
+set -euo pipefail
+
+# Minimum supported macOS version (major.minor)
+readonly MIN_MACOS_VERSION="12.0"
+
+# Validate Command Line Tools are installed
+validate_command_line_tools() {
+    local xcode_path
+    
+    # Check if xcode-select can find the developer directory
+    if xcode_path=$(xcode-select -p 2>/dev/null); then
+        # Verify the path exists and contains expected tools
+        if [[ -d "$xcode_path" && -f "$xcode_path/usr/bin/git" ]]; then
+            return 0
+        else
+            echo "Command Line Tools directory exists but appears incomplete" >&2
+            return 1
+        fi
+    else
+        echo "Command Line Tools not found. Install with: xcode-select --install" >&2
+        return 1
+    fi
+}
+
+# Validate network connectivity to essential services
+validate_network_connectivity() {
+    local hosts=("github.com" "raw.githubusercontent.com")
+    local failed_hosts=()
+    
+    for host in "${hosts[@]}"; do
+        # Use ping with timeout to test connectivity
+        if ! ping -c 1 -W 3000 "$host" >/dev/null 2>&1; then
+            failed_hosts+=("$host")
+        fi
+    done
+    
+    if [[ ${#failed_hosts[@]} -gt 0 ]]; then
+        echo "Network connectivity failed for: ${failed_hosts[*]}" >&2
+        echo "Please check your internet connection and try again" >&2
+        return 1
+    fi
+    
+    return 0
+}
+
+# Validate directory exists and has proper permissions
+validate_directory_permissions() {
+    local directory="$1"
+    
+    if [[ -z "$directory" ]]; then
+        echo "Directory path is required" >&2
+        return 1
+    fi
+    
+    # Check if directory exists
+    if [[ ! -d "$directory" ]]; then
+        echo "Directory does not exist: $directory" >&2
+        return 1
+    fi
+    
+    return 0
+}
+
+# Validate write permissions to a directory
+validate_write_permissions() {
+    local directory="$1"
+    
+    if [[ -z "$directory" ]]; then
+        echo "Directory path is required" >&2
+        return 1
+    fi
+    
+    # Check if directory exists first
+    if [[ ! -d "$directory" ]]; then
+        echo "Directory does not exist: $directory" >&2
+        return 1
+    fi
+    
+    # Test write permissions by creating a temporary file
+    local test_file="$directory/.dotfiles_write_test_$$"
+    if touch "$test_file" 2>/dev/null; then
+        rm -f "$test_file"
+        return 0
+    else
+        echo "No write permission for directory: $directory" >&2
+        return 1
+    fi
+}
+
+# Validate macOS version compatibility
+validate_macos_version() {
+    local current_version
+    local major minor
+    local min_major min_minor
+    
+    # Get current macOS version
+    current_version=$(sw_vers -productVersion 2>/dev/null)
+    if [[ -z "$current_version" ]]; then
+        echo "Unable to determine macOS version" >&2
+        return 1
+    fi
+    
+    # Parse current version
+    major=$(echo "$current_version" | cut -d. -f1)
+    minor=$(echo "$current_version" | cut -d. -f2)
+    
+    # Parse minimum version
+    min_major=$(echo "$MIN_MACOS_VERSION" | cut -d. -f1)
+    min_minor=$(echo "$MIN_MACOS_VERSION" | cut -d. -f2)
+    
+    # Compare versions
+    if [[ "$major" -gt "$min_major" ]] || 
+       [[ "$major" -eq "$min_major" && "$minor" -ge "$min_minor" ]]; then
+        return 0
+    else
+        echo "Unsupported macOS version: $current_version (minimum: $MIN_MACOS_VERSION)" >&2
+        return 1
+    fi
+}
+
+# Validate essential directories for dotfiles installation
+validate_essential_directories() {
+    local directories=(
+        "$HOME"
+        "/usr/local"
+        "/opt"
+    )
+    
+    local failed_dirs=()
+    
+    for dir in "${directories[@]}"; do
+        if ! validate_directory_permissions "$dir"; then
+            failed_dirs+=("$dir")
+        fi
+    done
+    
+    if [[ ${#failed_dirs[@]} -gt 0 ]]; then
+        echo "Essential directory validation failed for: ${failed_dirs[*]}" >&2
+        return 1
+    fi
+    
+    return 0
+}
+
+# Run comprehensive prerequisite validation
+run_prerequisite_validation() {
+    local validation_functions=(
+        "validate_command_line_tools"
+        "validate_network_connectivity"
+        "validate_macos_version"
+        "validate_essential_directories"
+    )
+    
+    local failed_validations=()
+    local exit_code=0
+    
+    echo "Running prerequisite validation checks..."
+    
+    for validation_func in "${validation_functions[@]}"; do
+        echo "  Checking: ${validation_func#validate_}"
+        
+        if ! "$validation_func"; then
+            failed_validations+=("$validation_func")
+            exit_code=1
+        else
+            echo "    ✓ Passed"
+        fi
+    done
+    
+    if [[ $exit_code -eq 0 ]]; then
+        echo "✅ All prerequisite validation checks passed"
+    else
+        echo "❌ Prerequisite validation failed:"
+        for failed_func in "${failed_validations[@]}"; do
+            echo "  - ${failed_func#validate_}"
+        done
+    fi
+    
+    return $exit_code
+}

--- a/features/tmux/utils.bash
+++ b/features/tmux/utils.bash
@@ -46,7 +46,8 @@ install_tpm() {
     echo "🍱 Installing tpm..."
     
     # Create plugins directory if it doesn't exist
-    local plugins_dir="$(dirname "$TPM_DIR")"
+    local plugins_dir
+    plugins_dir="$(dirname "$TPM_DIR")"
     if [[ ! -d "$plugins_dir" ]]; then
         mkdir -p "$plugins_dir"
     fi


### PR DESCRIPTION
## 💪 What

Migrates bash utility libraries from `bin/lib/` to the new `core/` directory structure:
- `bin/lib/machine-detection.zsh` → `core/detection/machine.bash`
- `bin/lib/dry-run-utils.zsh` → `core/dry-run/utils.bash`
- `bin/lib/error-handling.zsh` → `core/errors/handling.bash`
- `bin/lib/prerequisite-validation.zsh` → `core/prerequisites/validation.bash`

## 🤔 Why

This migration aligns with the new feature-based architecture being implemented across the dotfiles repository. Moving these core utilities unblocks the migration of Yazi and macOS features, which depend on machine detection functionality.

## 👀 Usage

No changes to usage - these are internal library files used by other scripts.

## 👩‍🔬 How to validate

1. Run the test suite to ensure no functionality is broken:
   ```bash
   ./test/run-tests.zsh
   ```

2. Verify the new file locations exist:
   ```bash
   ls -la core/detection/machine.bash
   ls -la core/dry-run/utils.bash
   ls -la core/errors/handling.bash
   ls -la core/prerequisites/validation.bash
   ```

## 🔗 Related links

- Epic: #43 (Feature-Based Architecture Migration)
- Epic: #54 (Complete Bash Migration)